### PR TITLE
feature: implement chapter name localization with translations

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -1,12 +1,13 @@
 class Chapter < ApplicationRecord
-  after_validation :set_slug, only: [ :create, :update ]
+  has_many :translations, class_name: "ChapterTranslation", dependent: :destroy
+
+  def translated_name
+    translations.find_by(locale: I18n.locale)&.name ||
+    translations.find_by(locale: I18n.default_locale)&.name ||
+    "Untranslated Chapter"
+  end
 
   def to_param
     "#{id}-#{slug}"
-  end
-
-  private
-  def set_slug
-    self.slug = name.to_s.parameterize
   end
 end

--- a/app/models/chapter_translation.rb
+++ b/app/models/chapter_translation.rb
@@ -1,0 +1,6 @@
+class ChapterTranslation < ApplicationRecord
+  belongs_to :chapter
+
+  validates :locale, presence: true, inclusion: { in: I18n.available_locales.map(&:to_s) }
+  validates :name, presence: true
+end

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -22,10 +22,10 @@
           </button>
           <div data-navbar-target="dropdown"
             class="absolute hidden opacity-0 scale-95 transition-all duration-200 ease-out bg-zinc-800 shadow-lg rounded-lg w-28">
-            <%- Chapter.all.each do |chapter| %>
+            <%- Chapter.includes(:translations).all.each do |chapter| %>
               <%= link_to t("nav.chapter#{chapter.position}"), chapter_path(chapter), class: "block px-3 py-2 hover:bg-zinc-700 hover:text-blue-400 text-center first:rounded-t-lg last:rounded-b-lg",
               data: { action: "mouseover->navbar#tooltipShow mouseout->navbar#tooltipHide",
-                      tooltip: chapter.name } %>
+                      tooltip: chapter.translated_name } %>
             <% end %>
           </div>
         </div>

--- a/app/views/shared/_toggle-locale.erb
+++ b/app/views/shared/_toggle-locale.erb
@@ -1,6 +1,6 @@
 <div class="flex items-center mx-4 my-2">
   <!-- Bangla label -->
-  <span class="font-medium mx-2 text-sm">বাংলা</span>
+  <span class="font-medium mx-2 text-sm"><%= t("nav.bangla") %></span>
   
   <%= form_tag change_locale_path, method: :post, id: "locale_form", class: "inline" do %>
     <!-- Toggle Switch -->
@@ -13,10 +13,10 @@
                       onclick: 'toggleLocale(this)' %>
       
       <!-- Toggle background -->
-      <div class="w-11 h-6 bg-gray-200 rounded-full peer peer-focus:ring-4 peer-focus:ring-blue-300 
+      <div class="w-11 h-6 bg-zinc-200 rounded-full peer peer-focus:ring-4 peer-focus:ring-blue-300 
                 peer-checked:after:translate-x-full peer-checked:after:border-white peer-checked:bg-blue-600 
-                after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white 
-                after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 
+                after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-green-400 
+                after:border-zinc-900 after:border after:rounded-full after:h-5 after:w-5 
                 after:transition-all"></div>
     </label>
     
@@ -25,7 +25,7 @@
   <% end %>
   
   <!-- English label -->
-  <span class="font-medium mx-2 text-sm">English</span>
+  <span class="font-medium mx-2 text-sm"><%= t("nav.english") %></span>
 </div>
 
 <script>

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -1,5 +1,7 @@
 bn:
   nav:
+    english: "ইংরেজি"
+    bangla: "বাংলা"
     ict: "আইসিটি" 
     title: "ঘর"
     home: "হোম"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,8 @@
 
 en:
   nav:
+    english: "English"
+    bangla: "Bengali"
     ict: "ICT"
     title: "Ghor"
     home: "Home"

--- a/db/migrate/20250429215343_remove_name_from_chapters.rb
+++ b/db/migrate/20250429215343_remove_name_from_chapters.rb
@@ -1,0 +1,5 @@
+class RemoveNameFromChapters < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :chapters, :name, :string
+  end
+end

--- a/db/migrate/20250429215635_create_chapter_translations.rb
+++ b/db/migrate/20250429215635_create_chapter_translations.rb
@@ -1,0 +1,11 @@
+class CreateChapterTranslations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :chapter_translations do |t|
+      t.string :locale
+      t.string :name
+      t.references :chapter, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_29_144345) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_29_215635) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
+  create_table "chapter_translations", force: :cascade do |t|
+    t.string "locale"
+    t.string "name"
+    t.bigint "chapter_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["chapter_id"], name: "index_chapter_translations_on_chapter_id"
+  end
+
   create_table "chapters", force: :cascade do |t|
-    t.string "name", null: false
     t.integer "position", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "slug"
   end
+
+  add_foreign_key "chapter_translations", "chapters"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,7 @@ Chapter.destroy_all
 
 # Create chapters with translations
 chapters = [
-  { 
+  {
     position: 1,
     translations: [
       { locale: 'en', name: "ICT: World and Bangladesh Perspective" },

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,19 +1,62 @@
 # Clear existing data (optional - use carefully in production)
 Chapter.destroy_all
 
-# Create chapters
+# Create chapters with translations
 chapters = [
-  { name: "ICT: World and Bangladesh Perspective", position: 1 },
-  { name: "Communication System and Networking", position: 2 },
-  { name: "Number System and Digital Device", position: 3 },
-  { name: "Web Design and HTML", position: 4 },
-  { name: "Programming Language", position: 5 },
-  { name: "Database Management System", position: 6 }
+  { 
+    position: 1,
+    translations: [
+      { locale: 'en', name: "ICT: World and Bangladesh Perspective" },
+      { locale: 'bn', name: "আইসিটি: বৈশ্বিক ও বাংলাদেশ প্রেক্ষাপট" }
+    ]
+  },
+  {
+    position: 2,
+    translations: [
+      { locale: 'en', name: "Communication System and Networking" },
+      { locale: 'bn', name: "যোগাযোগ ব্যবস্থা ও নেটওয়ার্কিং" }
+    ]
+  },
+  {
+    position: 3,
+    translations: [
+      { locale: 'en', name: "Number System and Digital Device" },
+      { locale: 'bn', name: "সংখ্যা পদ্ধতি ও ডিজিটাল ডিভাইস" }
+    ]
+  },
+  {
+    position: 4,
+    translations: [
+      { locale: 'en', name: "Web Design and HTML" },
+      { locale: 'bn', name: "ওয়েব ডিজাইন ও এইচটিএমএল" }
+    ]
+  },
+  {
+    position: 5,
+    translations: [
+      { locale: 'en', name: "Programming Language" },
+      { locale: 'bn', name: "প্রোগ্রামিং ভাষা" }
+    ]
+  },
+  {
+    position: 6,
+    translations: [
+      { locale: 'en', name: "Database Management System" },
+      { locale: 'bn', name: "ডাটাবেস ম্যানেজমেন্ট সিস্টেম" }
+    ]
+  }
 ]
 
-chapters.each do |chapter|
-  Chapter.create!(chapter)
-  puts "Created chapter: #{chapter[:name]}"
+chapters.each do |chapter_data|
+  chapter = Chapter.create!(position: chapter_data[:position])
+  chapter_data[:translations].each do |translation|
+    chapter.translations.create!(translation)
+  end
+  english_name = chapter.translations.find_by(locale: 'en').name
+  chapter.update!(slug: english_name.parameterize)
+  puts "Created chapter: #{chapter.translated_name} (Position: #{chapter.position})"
 end
 
-puts "Successfully created #{Chapter.count} chapters"
+puts "\nSuccessfully created:"
+puts "- #{Chapter.count} chapters"
+puts "- #{ChapterTranslation.count} translations"

--- a/test/controllers/chapters_controller_test.rb
+++ b/test/controllers/chapters_controller_test.rb
@@ -8,7 +8,7 @@ class ChaptersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get show" do
-    get chapter_url(chapters(:chapterOne))
+    get chapter_url(chapters(:chapter_one))
     assert_response :success
     assert_template "show"
   end

--- a/test/fixtures/chapter_translations.yml
+++ b/test/fixtures/chapter_translations.yml
@@ -1,0 +1,61 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+translation_one_en:
+  chapter: chapter_one
+  locale: en
+  name: "ICT: World and Bangladesh Perspective"
+
+translation_one_bn:
+  chapter: chapter_one
+  locale: bn
+  name: "আইসিটি: বৈশ্বিক ও বাংলাদেশ প্রেক্ষাপট"
+
+translation_two_en:
+  chapter: chapter_two
+  locale: en
+  name: "Communication System and Networking"
+
+translation_two_bn:
+  chapter: chapter_two
+  locale: bn
+  name: "যোগাযোগ ব্যবস্থা ও নেটওয়ার্কিং"
+
+translation_three_en:
+  chapter: chapter_three
+  locale: en
+  name: "Number System and Digital Device"
+
+translation_three_bn:
+  chapter: chapter_three
+  locale: bn
+  name: "সংখ্যা পদ্ধতি ও ডিজিটাল ডিভাইস"
+
+translation_four_en:
+  chapter: chapter_four
+  locale: en
+  name: "Web Design and HTML"
+
+translation_four_bn:
+  chapter: chapter_four
+  locale: bn
+  name: "ওয়েব ডিজাইন ও এইচটিএমএল"
+
+translation_five_en:
+  chapter: chapter_five
+  locale: en
+  name: "Programming Language"
+
+translation_five_bn:
+  chapter: chapter_five
+  locale: bn
+  name: "প্রোগ্রামিং ভাষা"
+
+translation_six_en:
+  chapter: chapter_six
+  locale: en
+  name: "Database Management System"
+
+translation_six_bn:
+  chapter: chapter_six
+  locale: bn
+  name: "ডাটাবেস ম্যানেজমেন্ট সিস্টেম"

--- a/test/fixtures/chapters.yml
+++ b/test/fixtures/chapters.yml
@@ -1,23 +1,24 @@
-chapterOne:
-  name: "ICT: World and Bangladesh Perspective"
+chapter_one:
+  slug: "ict-world-and-bangladesh-perspective"
   position: 1
 
-chapterTwo:
-  name: "Communication System and Networking"
+chapter_two:
+  slug: "communication-system-and-networking"
   position: 2
 
-chapterThree:
-  name: "Number System and Digital Device"
+chapter_three:
+  slug: "number-system-and-digital-device"
   position: 3
 
-chapterFour:
-  name: "Web Design and HTML"
+chapter_four:
+  slug: "web-design-and-html"
   position: 4
 
-chapterFive:
-  name: "Programming Language"
+chapter_five:
+  slug: "programming-language"
   position: 5
 
-chapterSix:
-  name: "Database Management System"
+chapter_six:
+  slug: "database-management-system"
   position: 6
+

--- a/test/models/chapter_translation_test.rb
+++ b/test/models/chapter_translation_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ChapterTranslationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- Added ChapterTranslation model for storing localized chapter names
- Updated seed data with English (en) and Bengali (bn) translations
- Implemented slug generation based on English chapter names
- Created test fixtures for chapters and translations
- Integrated localized names in views using I18n fallbacks
- Configured model relationships and validation constraints

This implementation allows:
- Multi-language support for chapter names
- SEO-friendly URLs via English-based slugs
- Easy addition of new languages
- Consistent test data with foreign key relationships