### PR TITLE
feature: Add github templates for easing the issues and pr creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,62 @@
+name: Bug Report
+description: Report a bug
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please fill out the sections below to help everyone identify and fix the bug
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - iOS
+        - Android
+        - Web
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type of bug
+      options:
+        - Crash
+        - UI Issue
+        - Performance Issue
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe your issue
+      placeholder: When I click here this happens
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to page X
+        2. Click here
+        3. Click there
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What was the expected result?
+      placeholder: I expected this to happen
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Put here any screenshots or videos (optional)
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting this issue! We will get back to you as soon as possible.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/new-feature.yml
+++ b/.github/ISSUE_TEMPLATE/new-feature.yml
@@ -1,0 +1,32 @@
+name: New feature
+description: Suggest or request a new feature
+labels: ["feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please fill out the sections below to properly describe the new feature you are suggesting.
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the feature
+      placeholder: A button in the screen X that allows to do Y
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Acceptance Criteria
+      placeholder: It will be accepted if ...
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      placeholder: |
+        Add any other context or screenshots about the feature request here.
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your input!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+## PR Description
+
+Please provide a clear and concise description of the changes introduced by this pull request. Explain the "why" behind the changes, not just the "what."
+
+## Related Issues
+
+If this PR addresses any specific issues, link them here using the format `Closes #<issue_number>` or `Fixes #<issue_number>`.
+
+## Summary of Changes
+
+List the key changes made in this PR:
+
+- [ ] Feature A implemented.
+- [ ] Bug B fixed.
+- [ ] Refactoring of module C.
+- [ ] Documentation updated.
+
+## Checklist
+
+Please ensure that you have completed the following items before submitting your PR:
+
+- [ ] Code follows the project's coding standards.
+- [ ] All tests pass successfully.
+- [ ] Code has been reviewed by at least one other team member.
+- [ ] The PR is labeled appropriately (e.g., `feature`, `bug`, `refactor`).
+- [ ] The PR targets the correct branch (e.g., `development`, `main`).
+
+## Screenshots/Videos (Optional)
+
+If the changes involve UI or visual elements, please provide screenshots or videos to demonstrate the changes.
+
+## Additional Notes (Optional)
+
+Any additional information or context that reviewers should be aware of.


### PR DESCRIPTION
Following files were added for following reasons
- .github/ISSUE_TEMPLATE/bug-report.yml for bug related issues
- .github/ISSUE_TEMPLATE/new-feature.yml for new feature requests type of issues
- .github/ISSUE_TEMPLATE/config.yml for allowing blank issues
- .github/PULL_REQUEST_TEMPLATE.md for PR template